### PR TITLE
feat: add data column sidecar event support for PeerDAS (EIP-7594)

### DIFF
--- a/pkg/beacon/event.go
+++ b/pkg/beacon/event.go
@@ -49,6 +49,7 @@ const (
 	topicVoluntaryExit        = "voluntary_exit"
 	topicContributionAndProof = "contribution_and_proof"
 	topicBlobSidecar          = "blob_sidecar"
+	topicDataColumnSidecar    = "data_column_sidecar"
 	topicEvent                = "raw_event"
 )
 
@@ -97,4 +98,12 @@ type FinalityCheckpointUpdated struct {
 
 // FirstTimeHealthyEvent is emitted when the node is first considered healthy.
 type FirstTimeHealthyEvent struct {
+}
+
+// DataColumnSidecarEvent represents a data column sidecar event for PeerDAS (EIP-7594).
+type DataColumnSidecarEvent struct {
+	Slot           phase0.Slot `json:"slot"`
+	Index          uint64      `json:"index"`
+	BlockRoot      phase0.Root `json:"block_root"`
+	KZGCommitments []string    `json:"kzg_commitments"`
 }

--- a/pkg/beacon/publisher.go
+++ b/pkg/beacon/publisher.go
@@ -46,6 +46,10 @@ func (n *node) publishBlobSidecar(ctx context.Context, event *v1.BlobSidecarEven
 	n.broker.Emit(topicBlobSidecar, event)
 }
 
+func (n *node) publishDataColumnSidecar(ctx context.Context, event *DataColumnSidecarEvent) {
+	n.broker.Emit(topicDataColumnSidecar, event)
+}
+
 func (n *node) publishEvent(ctx context.Context, event *v1.Event) {
 	n.broker.Emit(topicEvent, event)
 }

--- a/pkg/beacon/subscriptions.go
+++ b/pkg/beacon/subscriptions.go
@@ -96,6 +96,8 @@ func (n *node) handleEvent(ctx context.Context, event *v1.Event) error {
 		return n.handleContributionAndProof(ctx, event)
 	case topicBlobSidecar:
 		return n.handleBlobSidecar(ctx, event)
+	case topicDataColumnSidecar:
+		return n.handleDataColumnSidecar(ctx, event)
 
 	default:
 		return fmt.Errorf("unknown event topic %s", event.Topic)
@@ -197,6 +199,17 @@ func (n *node) handleBlobSidecar(ctx context.Context, event *v1.Event) error {
 	}
 
 	n.publishBlobSidecar(ctx, blobSidecar)
+
+	return nil
+}
+
+func (n *node) handleDataColumnSidecar(ctx context.Context, event *v1.Event) error {
+	dataColumnSidecar, valid := event.Data.(*DataColumnSidecarEvent)
+	if !valid {
+		return errors.New("invalid data column sidecar event")
+	}
+
+	n.publishDataColumnSidecar(ctx, dataColumnSidecar)
 
 	return nil
 }


### PR DESCRIPTION
## Summary
• Implements comprehensive support for data_column_sidecar events to enable PeerDAS data availability sampling
• Adds custom DataColumnSidecarEvent struct following beacon-APIs specification since it's not yet available in go-eth2-client

## Test plan
- [ ] Verify data_column_sidecar topic can be subscribed to in beacon subscription configuration
- [ ] Test event handling with mock DataColumnSidecarEvent data
- [ ] Confirm event publishing works correctly through the broker
- [ ] Validate struct JSON serialization matches expected format

🤖 Generated with [Claude Code](https://claude.ai/code)