### PR TITLE
ci(workflows): bump Go version from 1.22 to 1.24

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
-          go-version: 1.22
+          go-version: 1.24
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,7 +39,7 @@ linters:
     - unconvert
     - unused
     - whitespace
-    - wsl
+    - wsl_v5
   settings:
     errcheck:
       check-type-assertions: true
@@ -59,6 +59,10 @@ linters:
     nolintlint:
       require-explanation: true
       require-specific: true
+    wsl_v5:
+      allow-first-in-block: true
+      allow-whole-block: false
+      branch-max-lines: 2
   exclusions:
     generated: lax
     presets:
@@ -70,7 +74,7 @@ linters:
       - linters:
           - gocritic
           - gosec
-          - wsl
+          - wsl_v5
         path: _test\.go
     paths:
       - third_party$

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+golangci-lint 2.4.0

--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -236,8 +236,10 @@ func (n *node) Start(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 
 	n.lifecycleMu.Lock()
+
 	n.ctx = ctx
 	n.cancel = cancel
+
 	n.lifecycleMu.Unlock()
 
 	if n.options.PrometheusMetrics {
@@ -321,9 +323,11 @@ func (n *node) Stop(ctx context.Context) error {
 	}
 
 	n.lifecycleMu.Lock()
+
 	if n.cancel != nil {
 		n.cancel()
 	}
+
 	n.lifecycleMu.Unlock()
 
 	return nil

--- a/pkg/beacon/beacon_test.go
+++ b/pkg/beacon/beacon_test.go
@@ -33,8 +33,10 @@ func TestLifecycleMutex(t *testing.T) {
 
 				// This simulates what Start() does
 				n.lifecycleMu.Lock()
+
 				n.ctx = ctx
 				n.cancel = cancel
+
 				n.lifecycleMu.Unlock()
 
 				// Clean up
@@ -50,9 +52,11 @@ func TestLifecycleMutex(t *testing.T) {
 
 				// This simulates what Stop() does
 				n.lifecycleMu.Lock()
+
 				if n.cancel != nil {
 					n.cancel()
 				}
+
 				n.lifecycleMu.Unlock()
 			}()
 		}
@@ -61,8 +65,10 @@ func TestLifecycleMutex(t *testing.T) {
 
 		// Reset for next iteration
 		n.lifecycleMu.Lock()
+
 		n.ctx = nil
 		n.cancel = nil
+
 		n.lifecycleMu.Unlock()
 	}
 }
@@ -82,23 +88,30 @@ func TestLifecycleStartStopSequence(t *testing.T) {
 
 	// Before Start, cancel should be nil
 	n.lifecycleMu.Lock()
+
 	if n.cancel != nil {
 		t.Error("cancel should be nil before Start")
 	}
+
 	n.lifecycleMu.Unlock()
 
 	// Simulate Start without actually starting (to avoid bootstrap errors)
 	startCtx, startCancel := context.WithCancel(ctx)
+
 	n.lifecycleMu.Lock()
+
 	n.ctx = startCtx
 	n.cancel = startCancel
+
 	n.lifecycleMu.Unlock()
 
 	// Verify cancel is set
 	n.lifecycleMu.Lock()
+
 	if n.cancel == nil {
 		t.Error("cancel should not be nil after Start")
 	}
+
 	n.lifecycleMu.Unlock()
 
 	// Stop should work without race


### PR DESCRIPTION
ci(lint): replace deprecated wsl linter with wsl_v5
ci(lint): add .tool-versions to pin golangci-lint at 2.4.0
style(beacon): add blank lines after mutex lock for wsl_v5