### PR TITLE
feat: deliver flat execution_payload / _gossip events

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/chuckpreslar/emission v0.0.0-20170206194824-a7ddd980baf9
 	github.com/ethereum/go-ethereum v1.17.3-0.20260507223249-73944e329925
 	github.com/ethpandaops/ethwallclock v0.2.0
-	github.com/ethpandaops/go-eth2-client v0.1.3-0.20260513062559-5fb497ba414f
+	github.com/ethpandaops/go-eth2-client v0.1.6-0.20260708061330-ed85bf5c3bab
 	github.com/go-co-op/gocron v1.16.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/prometheus/client_model v0.6.2
@@ -34,8 +34,8 @@ require (
 	github.com/mattn/go-colorable v0.1.14 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/pk910/dynamic-ssz v1.3.2-0.20260505131440-111bcb265c8f // indirect
-	github.com/pk910/hashtree-bindings v0.1.0 // indirect
+	github.com/pk910/dynamic-ssz v1.3.2 // indirect
+	github.com/pk910/hashtree-bindings v0.2.2 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/common v0.66.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -22,8 +22,8 @@ github.com/ethereum/go-ethereum v1.17.3-0.20260507223249-73944e329925 h1:d0kQnVK
 github.com/ethereum/go-ethereum v1.17.3-0.20260507223249-73944e329925/go.mod h1:f2EhRwqewIZkGoQekywI2Y2RZAMTSavLNkD9qItFy1A=
 github.com/ethpandaops/ethwallclock v0.2.0 h1:EeFKtZ7v6TAdn/oAh0xaPujD7N4amjBxrWIByraUfLM=
 github.com/ethpandaops/ethwallclock v0.2.0/go.mod h1:y0Cu+mhGLlem19vnAV2x0hpFS5KZ7oOi2SWYayv9l24=
-github.com/ethpandaops/go-eth2-client v0.1.3-0.20260513062559-5fb497ba414f h1:9k0z0tEayikToEqZn71xKIRtCNzH6mwUkIJk70kbSSk=
-github.com/ethpandaops/go-eth2-client v0.1.3-0.20260513062559-5fb497ba414f/go.mod h1:U3KdR8QSq8vqs9LWSGAF4ETHJpcB62E1DFf0gVMgWv0=
+github.com/ethpandaops/go-eth2-client v0.1.6-0.20260708061330-ed85bf5c3bab h1:lOnMzC2Oyzd+hJ0BOH1HXXYou1jMnlX2dVsP8vztX7U=
+github.com/ethpandaops/go-eth2-client v0.1.6-0.20260708061330-ed85bf5c3bab/go.mod h1:97Oq3omOQSGPPYgrbsOIIw2Pc4T5Ph21f8ZRyHJQBHU=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
@@ -88,10 +88,10 @@ github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9k
 github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7JYyY=
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
-github.com/pk910/dynamic-ssz v1.3.2-0.20260505131440-111bcb265c8f h1:k1Dn2h+msg+T0c25hoiJ739ckCNt1dqKErLylois7ss=
-github.com/pk910/dynamic-ssz v1.3.2-0.20260505131440-111bcb265c8f/go.mod h1:ARK5qDyrJ/MHpaZHGJYvCKElvaMYTE9pXOQbvPDeE0U=
-github.com/pk910/hashtree-bindings v0.1.0 h1:w7NyRWFi2OaYEFvo9ADcE/QU6PMuVLl3hBgx92KiH9c=
-github.com/pk910/hashtree-bindings v0.1.0/go.mod h1:zrWt88783JmhBfcgni6kkIMYRdXTZi/FL//OyI5T/l4=
+github.com/pk910/dynamic-ssz v1.3.2 h1:65UR/O+ss+U2Dn86Rdl7LwehHo3u2ElutduS/pcuUXE=
+github.com/pk910/dynamic-ssz v1.3.2/go.mod h1:lqmnou2bjr2UWQ3C/L3082TGW0SFl/SwT7ionwM0+FU=
+github.com/pk910/hashtree-bindings v0.2.2 h1:gkczxxekBW2NeMK9N3OLj7Jepe7zPmJGVwr8LyofGsA=
+github.com/pk910/hashtree-bindings v0.2.2/go.mod h1:zrWt88783JmhBfcgni6kkIMYRdXTZi/FL//OyI5T/l4=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -138,10 +138,10 @@ type Node interface {
 	OnFastConfirmation(ctx context.Context, handler func(ctx context.Context, ev *v1.FastConfirmationEvent) error)
 
 	// EIP-7732 ePBS subscriptions.
-	// OnExecutionPayload is called when a SignedExecutionPayloadEnvelope has been imported into fork-choice.
-	OnExecutionPayload(ctx context.Context, handler func(ctx context.Context, ev *gloas.SignedExecutionPayloadEnvelope) error)
-	// OnExecutionPayloadGossip is called when a SignedExecutionPayloadEnvelope has passed gossip validation.
-	OnExecutionPayloadGossip(ctx context.Context, handler func(ctx context.Context, ev *gloas.SignedExecutionPayloadEnvelope) error)
+	// OnExecutionPayload is called when an execution payload has been imported into fork-choice.
+	OnExecutionPayload(ctx context.Context, handler func(ctx context.Context, ev *v1.ExecutionPayloadEvent) error)
+	// OnExecutionPayloadGossip is called when an execution payload has passed gossip validation.
+	OnExecutionPayloadGossip(ctx context.Context, handler func(ctx context.Context, ev *v1.ExecutionPayloadEvent) error)
 	// OnExecutionPayloadAvailable is called when the node has verified the execution payload and blobs are locally available.
 	OnExecutionPayloadAvailable(ctx context.Context, handler func(ctx context.Context, ev *v1.ExecutionPayloadAvailableEvent) error)
 	// OnExecutionPayloadBid is called when a SignedExecutionPayloadBid passes gossip validation.

--- a/pkg/beacon/publisher.go
+++ b/pkg/beacon/publisher.go
@@ -125,11 +125,11 @@ func (n *node) publishSingleAttestation(ctx context.Context, event *electra.Sing
 }
 
 // EIP-7732 ePBS beacon SSE event publishers.
-func (n *node) publishExecutionPayload(ctx context.Context, event *gloas.SignedExecutionPayloadEnvelope) {
+func (n *node) publishExecutionPayload(ctx context.Context, event *v1.ExecutionPayloadEvent) {
 	n.broker.Emit(topicExecutionPayload, event)
 }
 
-func (n *node) publishExecutionPayloadGossip(ctx context.Context, event *gloas.SignedExecutionPayloadEnvelope) {
+func (n *node) publishExecutionPayloadGossip(ctx context.Context, event *v1.ExecutionPayloadEvent) {
 	n.broker.Emit(topicExecutionPayloadGossip, event)
 }
 

--- a/pkg/beacon/subscriber.go
+++ b/pkg/beacon/subscriber.go
@@ -91,14 +91,14 @@ func (n *node) OnSingleAttestation(ctx context.Context, handler func(ctx context
 }
 
 // EIP-7732 ePBS beacon SSE event handlers.
-func (n *node) OnExecutionPayload(ctx context.Context, handler func(ctx context.Context, event *gloas.SignedExecutionPayloadEnvelope) error) {
-	n.broker.On(topicExecutionPayload, func(event *gloas.SignedExecutionPayloadEnvelope) {
+func (n *node) OnExecutionPayload(ctx context.Context, handler func(ctx context.Context, event *v1.ExecutionPayloadEvent) error) {
+	n.broker.On(topicExecutionPayload, func(event *v1.ExecutionPayloadEvent) {
 		n.handleSubscriberError(handler(ctx, event), topicExecutionPayload)
 	})
 }
 
-func (n *node) OnExecutionPayloadGossip(ctx context.Context, handler func(ctx context.Context, event *gloas.SignedExecutionPayloadEnvelope) error) {
-	n.broker.On(topicExecutionPayloadGossip, func(event *gloas.SignedExecutionPayloadEnvelope) {
+func (n *node) OnExecutionPayloadGossip(ctx context.Context, handler func(ctx context.Context, event *v1.ExecutionPayloadEvent) error) {
+	n.broker.On(topicExecutionPayloadGossip, func(event *v1.ExecutionPayloadEvent) {
 		n.handleSubscriberError(handler(ctx, event), topicExecutionPayloadGossip)
 	})
 }

--- a/pkg/beacon/subscriptions.go
+++ b/pkg/beacon/subscriptions.go
@@ -256,23 +256,23 @@ func (n *node) handleDataColumnSidecar(ctx context.Context, event *v1.Event) err
 }
 
 func (n *node) handleExecutionPayload(ctx context.Context, event *v1.Event) error {
-	envelope, valid := event.Data.(*gloas.SignedExecutionPayloadEnvelope)
+	ev, valid := event.Data.(*v1.ExecutionPayloadEvent)
 	if !valid {
 		return errors.New("invalid execution payload event")
 	}
 
-	n.publishExecutionPayload(ctx, envelope)
+	n.publishExecutionPayload(ctx, ev)
 
 	return nil
 }
 
 func (n *node) handleExecutionPayloadGossip(ctx context.Context, event *v1.Event) error {
-	envelope, valid := event.Data.(*gloas.SignedExecutionPayloadEnvelope)
+	ev, valid := event.Data.(*v1.ExecutionPayloadEvent)
 	if !valid {
 		return errors.New("invalid execution payload gossip event")
 	}
 
-	n.publishExecutionPayloadGossip(ctx, envelope)
+	n.publishExecutionPayloadGossip(ctx, ev)
 
 	return nil
 }


### PR DESCRIPTION
The EIP-7732 `execution_payload` and `execution_payload_gossip` SSE events carry a flat payload summary, not a full `SignedExecutionPayloadEnvelope`. go-eth2-client now decodes them into `api/v1.ExecutionPayloadEvent`; route that type through the broker (`subscriptions`/`publisher`/`subscriber` + the `Node` interface) instead of the envelope.

Previously every event failed the `event.Data` type assertion and was dropped, so `OnExecutionPayload` / `OnExecutionPayloadGossip` never fired.

Bumps go-eth2-client to the flat-event build (ethpandaops/go-eth2-client#39).

Depends on ethpandaops/go-eth2-client#39.

https://claude.ai/code/session_014KRVmYwRSsK5pFbghweigM