### PR TITLE
Fix nil pointer panic on invalid terminal total difficulty

### DIFF
--- a/pkg/beacon/state/spec.go
+++ b/pkg/beacon/state/spec.go
@@ -117,8 +117,9 @@ func NewSpec(data map[string]any) Spec {
 	if terminalTotalDifficulty, exists := data["TERMINAL_TOTAL_DIFFICULTY"]; exists {
 		ttd := cast.ToString(fmt.Sprintf("%v", terminalTotalDifficulty))
 
-		casted, _ := (*big.NewInt(0)).SetString(ttd, 10)
-		spec.TerminalTotalDifficulty = *casted
+		if casted, ok := new(big.Int).SetString(ttd, 10); ok {
+			spec.TerminalTotalDifficulty = *casted
+		}
 	}
 
 	if maxDeposits, exists := data["MAX_DEPOSITS"]; exists {

--- a/pkg/beacon/state/spec_test.go
+++ b/pkg/beacon/state/spec_test.go
@@ -1,0 +1,56 @@
+package state
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewSpec_TerminalTotalDifficulty(t *testing.T) {
+	tests := []struct {
+		name     string
+		value    any
+		expected string
+	}{
+		{
+			name:     "decimal string parses correctly",
+			value:    "58750000000000000000000",
+			expected: "58750000000000000000000",
+		},
+		{
+			name:     "zero parses correctly",
+			value:    "0",
+			expected: "0",
+		},
+		{
+			name:     "hex-encoded byte slice does not panic and leaves the zero value",
+			value:    []byte{0xc7, 0x0d, 0x80, 0x8a, 0x12, 0x8d, 0x73, 0x80},
+			expected: "0",
+		},
+		{
+			name:     "non-numeric string does not panic and leaves the zero value",
+			value:    "not-a-number",
+			expected: "0",
+		},
+		{
+			name:     "empty string does not panic and leaves the zero value",
+			value:    "",
+			expected: "0",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.NotPanics(t, func() {
+				spec := NewSpec(map[string]any{"TERMINAL_TOTAL_DIFFICULTY": tt.value})
+				assert.Equal(t, tt.expected, spec.TerminalTotalDifficulty.String())
+			})
+		})
+	}
+
+	t.Run("field absent leaves the zero value", func(t *testing.T) {
+		spec := NewSpec(map[string]any{})
+		assert.Equal(t, big.NewInt(0).String(), spec.TerminalTotalDifficulty.String())
+	})
+}


### PR DESCRIPTION
## Summary

state.NewSpec discarded the ok flag from big.Int.SetString and dereferenced the result unconditionally. SetString returns nil on any parse failure, so a spec response with a non-decimal TERMINAL_TOTAL_DIFFICULTY value (for example a hex-encoded one) crashes the caller with a nil pointer dereference.

Fix leaves the field at its zero value when parsing fails instead of dereferencing a nil result.

## Test plan

- [x] Added table-driven tests in pkg/beacon/state/spec_test.go covering decimal, zero, hex-encoded bytes, non-numeric string, empty string, and absent field
- [x] Confirmed the new tests fail against the old code and pass against the fix
- [x] go build ./..., go vet ./..., go test -race ./... all green