### PR TITLE
Fix shared slice mutation in fork schedule builder

### DIFF
--- a/pkg/beacon/state/scheduled_fork.go
+++ b/pkg/beacon/state/scheduled_fork.go
@@ -14,10 +14,15 @@ type ScheduledFork struct {
 
 // ForkScheduleFromForkEpochs returns a fork schedule from a list of forks.
 func ForkScheduleFromForkEpochs(forks ForkEpochs) ([]*ScheduledFork, error) {
-	// Sort them by Epoch.
-	sort.Slice(forks, func(i, j int) bool {
-		return (forks)[i].Epoch < (forks)[j].Epoch
+	// Sort a copy by Epoch so we don't reorder the caller's backing array.
+	sorted := make(ForkEpochs, len(forks))
+	copy(sorted, forks)
+
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Epoch < sorted[j].Epoch
 	})
+
+	forks = sorted
 
 	scheduled := make([]*ScheduledFork, 0, len(forks))
 

--- a/pkg/beacon/state/scheduled_fork_test.go
+++ b/pkg/beacon/state/scheduled_fork_test.go
@@ -1,0 +1,73 @@
+package state
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/ethpandaops/go-eth2-client/spec"
+	"github.com/ethpandaops/go-eth2-client/spec/phase0"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestForkScheduleFromForkEpochs_DoesNotMutateInput(t *testing.T) {
+	forks := ForkEpochs{
+		{Epoch: 74240, Name: spec.DataVersionAltair, Version: "0x01000000"},
+		{Epoch: 0, Name: spec.DataVersionPhase0, Version: "0x00000000"},
+		{Epoch: 194048, Name: spec.DataVersionBellatrix, Version: "0x02000000"},
+	}
+
+	before := make([]spec.DataVersion, len(forks))
+	for i, f := range forks {
+		before[i] = f.Name
+	}
+
+	scheduled, err := ForkScheduleFromForkEpochs(forks)
+	assert.NoError(t, err)
+	assert.Len(t, scheduled, 3)
+
+	after := make([]spec.DataVersion, len(forks))
+	for i, f := range forks {
+		after[i] = f.Name
+	}
+
+	assert.Equal(t, before, after, "ForkScheduleFromForkEpochs must not reorder the caller's slice")
+
+	// The returned schedule should still be sorted ascending by epoch,
+	// independent of the input order.
+	assert.Equal(t, "0", scheduled[0].Epoch)
+	assert.Equal(t, "74240", scheduled[1].Epoch)
+	assert.Equal(t, "194048", scheduled[2].Epoch)
+}
+
+func TestForkScheduleFromForkEpochs_ConcurrentWithReader(t *testing.T) {
+	forks := ForkEpochs{}
+	for i := range 50 {
+		forks = append(forks, &ForkEpoch{Epoch: phase0.Epoch(i * 1000), Name: spec.DataVersionPhase0})
+	}
+
+	var wg sync.WaitGroup
+
+	// Writer: repeatedly builds a schedule from the shared slice, the same
+	// way a consumer rendering a fork schedule page would.
+	for range 4 {
+		wg.Go(func() {
+			for range 50 {
+				_, err := ForkScheduleFromForkEpochs(forks)
+				assert.NoError(t, err)
+			}
+		})
+	}
+
+	// Reader: the same access pattern ForkMetrics.calculateCurrent uses.
+	for range 4 {
+		wg.Go(func() {
+			for range 50 {
+				for _, fork := range forks {
+					_ = fork.Name.String()
+				}
+			}
+		})
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Summary

ForkScheduleFromForkEpochs sorted its argument in place with sort.Slice. Since a slice argument shares its backing array with the caller, calling this read-shaped, innocuously named method reorders the caller's Spec.ForkEpochs out from under it, and races against anything else reading that slice concurrently, such as the fork metrics job that runs by default.

Fix sorts a copy instead, the same way BlobSchedule.GetMaxBlobsPerBlock already does.

## Test plan

- [x] Added tests in pkg/beacon/state/scheduled_fork_test.go: one confirming the caller's slice is no longer reordered, one running the builder concurrently against a reader using the same access pattern as ForkMetrics.calculateCurrent
- [x] Confirmed both fail against the old code (mutation test fails outright, race test fails under -race) and pass against the fix
- [x] go build ./..., go vet ./..., go test -race ./... all green