### PR TITLE
Fix PreviousFork never selecting a fork at epoch 0

### DIFF
--- a/pkg/beacon/state/fork_epoch.go
+++ b/pkg/beacon/state/fork_epoch.go
@@ -112,7 +112,7 @@ func (f *ForkEpochs) PreviousFork(epoch phase0.Epoch) (*ForkEpoch, error) {
 	}
 
 	for _, fork := range f.Active(epoch) {
-		if fork.Active(epoch) && fork.Name != current.Name && fork.Epoch > largest.Epoch {
+		if fork.Active(epoch) && fork.Name != current.Name && fork.Epoch >= largest.Epoch {
 			found = true
 
 			largest = fork

--- a/pkg/beacon/state/fork_epoch_test.go
+++ b/pkg/beacon/state/fork_epoch_test.go
@@ -232,6 +232,49 @@ func TestForkEpochsPreviousFork(t *testing.T) {
 				Name:  spec.DataVersionPhase0,
 			},
 		},
+		{
+			// Mainnet-shaped: genesis fork activates at epoch 0, which every
+			// real chain has. Regression test for a bug where a fork at
+			// epoch 0 could never be selected as the previous fork.
+			name: "returns genesis fork at epoch 0 as the previous fork",
+			forks: state.ForkEpochs{
+				{
+					Epoch: 0,
+					Name:  spec.DataVersionPhase0,
+				},
+				{
+					Epoch: 74240,
+					Name:  spec.DataVersionAltair,
+				},
+			},
+			epoch: 74241,
+			expected: &state.ForkEpoch{
+				Epoch: 0,
+				Name:  spec.DataVersionPhase0,
+			},
+		},
+		{
+			name: "returns the most recent previous fork across three activated forks",
+			forks: state.ForkEpochs{
+				{
+					Epoch: 0,
+					Name:  spec.DataVersionPhase0,
+				},
+				{
+					Epoch: 100,
+					Name:  spec.DataVersionAltair,
+				},
+				{
+					Epoch: 200,
+					Name:  spec.DataVersionBellatrix,
+				},
+			},
+			epoch: 250,
+			expected: &state.ForkEpoch{
+				Epoch: 100,
+				Name:  spec.DataVersionAltair,
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
## Summary

The search seeded its running maximum at epoch 0 and only replaced it on a strict greater than, so a fork activating at epoch 0 could never win. Every real chain has its genesis fork at epoch 0, so PreviousFork returned "no previous fork" on any mainnet-shaped spec.

Fix changes the comparison to greater than or equal, matching how CurrentFork already does this same search.

## Test plan

- [x] Added mainnet-shaped test cases to TestForkEpochsPreviousFork in pkg/beacon/state/fork_epoch_test.go: genesis fork at epoch 0, and a three-fork chain confirming the most recent previous fork is still picked correctly
- [x] Confirmed the new cases fail against the old strict comparison and pass against the fix
- [x] go build ./..., go vet ./..., go test -race ./... all green