### PR TITLE
Fix Genesis() silently returning nil instead of an error

### DIFF
--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -372,6 +372,10 @@ func (n *node) Genesis() (*v1.Genesis, error) {
 	n.genesisMu.RLock()
 	defer n.genesisMu.RUnlock()
 
+	if n.genesis == nil {
+		return nil, errors.New("genesis is not available")
+	}
+
 	return n.genesis, nil
 }
 

--- a/pkg/beacon/beacon_test.go
+++ b/pkg/beacon/beacon_test.go
@@ -123,3 +123,24 @@ func TestLifecycleStartStopSequence(t *testing.T) {
 		t.Error("context was not cancelled after Stop")
 	}
 }
+
+// TestGenesisErrorsWhenUnset matches Spec()'s behavior: both are cached
+// values that may not be ready yet, and a consumer applying the same
+// err-checking idiom to either one should get the same contract.
+func TestGenesisErrorsWhenUnset(t *testing.T) {
+	n := &node{log: logrus.New()}
+
+	_, err := n.Spec()
+	if err == nil {
+		t.Fatal("expected Spec() to error when unset")
+	}
+
+	g, err := n.Genesis()
+	if err == nil {
+		t.Fatal("expected Genesis() to error when unset, matching Spec()")
+	}
+
+	if g != nil {
+		t.Fatalf("expected a nil genesis alongside the error, got %v", g)
+	}
+}


### PR DESCRIPTION
## Summary

Spec() and Genesis() are both cached values that may not be ready before bootstrap completes, but Spec() returned an error on unset while Genesis() returned a bare nil. A consumer checking the error the same way for both, a reasonable assumption given the shared shape, nil derefs on Genesis instead of getting an error back.

Fix makes Genesis() share the same contract as Spec().

## Test plan

- [x] Added TestGenesisErrorsWhenUnset in pkg/beacon/beacon_test.go, confirming both getters error on unset
- [x] Confirmed the test fails against the old code and passes against the fix
- [x] go build ./..., go vet ./..., go test -race ./... all green