### PR TITLE
Remove dead Ready and lastEventTime fields

### DIFF
--- a/pkg/beacon/beacon.go
+++ b/pkg/beacon/beacon.go
@@ -182,23 +182,19 @@ type node struct {
 	broker *emission.Emitter
 
 	// Internal data stores
-	genesis         *v1.Genesis
-	genesisMu       sync.RWMutex
-	lastEventTime   time.Time
-	lastEventTimeMu sync.RWMutex
-	nodeVersion     string
-	nodeVersionMu   sync.RWMutex
-	peers           types.Peers
-	finality        *v1.Finality
-	spec            *state.Spec
-	specMu          sync.RWMutex
-	wallclock       *ethwallclock.EthereumBeaconChain
+	genesis       *v1.Genesis
+	genesisMu     sync.RWMutex
+	nodeVersion   string
+	nodeVersionMu sync.RWMutex
+	peers         types.Peers
+	finality      *v1.Finality
+	spec          *state.Spec
+	specMu        sync.RWMutex
+	wallclock     *ethwallclock.EthereumBeaconChain
 
 	stat *Status
 
 	metrics *Metrics
-
-	Ready bool
 
 	hasEmittedFirstTimeHealthy bool
 	firstHealthyMutex          sync.Mutex
@@ -405,8 +401,6 @@ func (n *node) bootstrap(ctx context.Context) error {
 
 	//nolint:errcheck // we dont care if this errors out since it runs indefinitely in a goroutine
 	go n.ensureBeaconSubscription(ctx)
-
-	n.Ready = true
 
 	go n.publishReady(ctx)
 

--- a/pkg/beacon/subscriptions.go
+++ b/pkg/beacon/subscriptions.go
@@ -60,10 +60,6 @@ func (n *node) subscribeToBeaconEvents(ctx context.Context) error {
 		if err := provider.Events(ctx, &api.EventsOpts{
 			Topics: []string{topic},
 			Handler: func(event *v1.Event) {
-				n.lastEventTimeMu.Lock()
-				n.lastEventTime = time.Now()
-				n.lastEventTimeMu.Unlock()
-
 				if err := n.handleEvent(ctx, event); err != nil {
 					n.log.Errorf("Failed to handle event: %v", err)
 				}


### PR DESCRIPTION
## Summary

Ready is only ever written, never read, and isn't exposed on the Node interface, so no consumer can reach it either. lastEventTime has the same shape: a dedicated mutex guarding a field nobody reads. Neither affects behavior, they're just state nothing observes.

## Test plan

- [x] No new test: this removes unreachable state rather than changing behavior, so the existing suite passing is the regression check
- [x] go build ./..., go vet ./..., go test -race ./... all green